### PR TITLE
Add runtime OS toggle via Button 1 + Button 4 combo

### DIFF
--- a/code.py
+++ b/code.py
@@ -81,20 +81,14 @@ keyboard = Keyboard(usb_hid.devices)
 
 
 while True:
-    # Toggle between Windows and MacOS by pressing Button 1 + Button 4 together
+    # Button 1 + Button 4: Switch to Windows mode
     if button1.value is False and button4.value is False:
-        WINDOWS = not WINDOWS
-        if WINDOWS:
+        if not WINDOWS:
+            WINDOWS = True
             CMD = Keycode.CONTROL
             print("Switched to Windows mode")
-        else:
-            CMD = Keycode.COMMAND
-            print("Switched to MacOS mode")
-        # LED feedback: blink to confirm switch
-        # 1 blink = MacOS, 2 blinks = Windows
         if LEDS:
-            blink_count = 2 if WINDOWS else 1
-            for _ in range(blink_count):
+            for _ in range(2):
                 led1.value = True
                 led2.value = True
                 led3.value = True
@@ -106,8 +100,28 @@ while True:
                 led4.value = False
                 time.sleep(OS_SWITCH_BLINK_TIME)
         time.sleep(DEBOUNCE_TIME)
-        # Wait for both buttons to be released
         while button1.value is False or button4.value is False:
+            time.sleep(0.01)
+
+    # Button 2 + Button 3: Switch to MacOS mode
+    if button2.value is False and button3.value is False:
+        if WINDOWS:
+            WINDOWS = False
+            CMD = Keycode.COMMAND
+            print("Switched to MacOS mode")
+        if LEDS:
+            led1.value = True
+            led2.value = True
+            led3.value = True
+            led4.value = True
+            time.sleep(OS_SWITCH_BLINK_TIME)
+            led1.value = False
+            led2.value = False
+            led3.value = False
+            led4.value = False
+            time.sleep(OS_SWITCH_BLINK_TIME)
+        time.sleep(DEBOUNCE_TIME)
+        while button2.value is False or button3.value is False:
             time.sleep(0.01)
 
     if button1.value is False:  # Button pressed (active low)

--- a/code.py
+++ b/code.py
@@ -7,9 +7,8 @@ from adafruit_hid.keycode import Keycode
 import time
 
 # Configuration
-WINDOWS = True  # Set to True for Windows, False for MacOS
+WINDOWS = True  # Set to True for Windows, False for MacOS (default on startup)
 LEDS = True  # Set to True to enable LEDs, False to disable
-
 
 CMD = Keycode.CONTROL  # Default to CONTROL for Windows
 if not WINDOWS:
@@ -18,6 +17,7 @@ if not WINDOWS:
 # Constants
 DEBOUNCE_TIME = 0.1  # Debounce time set at this number of seconds
 STARTUP_BLINK_TIME = 0.2  # The LEDs blink at start up for this number of seconds
+OS_SWITCH_BLINK_TIME = 0.15  # LED blink speed when switching OS mode
 
 # Setting up the buttons
 # Button 1 (Hand) on GPIO14
@@ -81,6 +81,35 @@ keyboard = Keyboard(usb_hid.devices)
 
 
 while True:
+    # Toggle between Windows and MacOS by pressing Button 1 + Button 4 together
+    if button1.value is False and button4.value is False:
+        WINDOWS = not WINDOWS
+        if WINDOWS:
+            CMD = Keycode.CONTROL
+            print("Switched to Windows mode")
+        else:
+            CMD = Keycode.COMMAND
+            print("Switched to MacOS mode")
+        # LED feedback: blink to confirm switch
+        # 1 blink = MacOS, 2 blinks = Windows
+        if LEDS:
+            blink_count = 2 if WINDOWS else 1
+            for _ in range(blink_count):
+                led1.value = True
+                led2.value = True
+                led3.value = True
+                led4.value = True
+                time.sleep(OS_SWITCH_BLINK_TIME)
+                led1.value = False
+                led2.value = False
+                led3.value = False
+                led4.value = False
+                time.sleep(OS_SWITCH_BLINK_TIME)
+        time.sleep(DEBOUNCE_TIME)
+        # Wait for both buttons to be released
+        while button1.value is False or button4.value is False:
+            time.sleep(0.01)
+
     if button1.value is False:  # Button pressed (active low)
         if LEDS:
             led1.value = not led1.value  # This toggles the LED on / off


### PR DESCRIPTION
## Summary
- Press **Button 1 (Hand) + Button 4 (End Call)** together to switch to Windows mode
- Press **Button 2 (Camera) + Button 3 (Mute)** together to switch to macOS mode
- No longer need to edit `code.py` and re-upload to switch OS — just press the button combo
- LED feedback confirms the switch: 2 blinks = Windows, 1 blink = macOS

## Test plan
- [ ] Flash updated `code.py` to RP2040
- [ ] Verify default startup mode matches `WINDOWS` flag
- [ ] Press Button 1 + Button 4 — confirm 2 LED blinks and Windows mode is active
- [ ] Press Button 2 + Button 3 — confirm 1 LED blink and macOS mode is active
- [ ] Test individual buttons still send correct shortcuts in both modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)